### PR TITLE
Add a vbsPath option for use within electron

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -84,13 +84,13 @@ const library = {
   },
 
   // WINDOWS
-  produceWindowsVBSPath: function () {
-    return path.join(__dirname, 'windows.vbs');
+  produceWindowsVBSPath: function (options) {
+    return options.windows.vbsPath;
   },
   makeWindowsShortcut: function (options) {
     let success = true;
 
-    const vbsScript = this.produceWindowsVBSPath();
+    const vbsScript = this.produceWindowsVBSPath(options);
     const filePathName = path.parse(options.windows.filePath).name;
     if (!fs.existsSync(vbsScript)) {
       helpers.throwError(options, 'Could not locate required "windows.vbs" file.');

--- a/src/validation.js
+++ b/src/validation.js
@@ -263,13 +263,13 @@ const validation = {
     return options;
   },
   validateWindowsScript: function (options) {
-    options = this.validateOutputPath(options, "windows");
-    options = this.validateOptionalString(options, "windows", "vbsPath");
+    options = this.validateOutputPath(options, 'windows');
+    options = this.validateOptionalString(options, 'windows', 'vbsPath');
 
     options.windows.vbsPath =
-      "vbsPath" in options.windows
+      'vbsPath' in options.windows
         ? options.windows.vbsPath
-        : path.join(__dirname, "windows.vbs");
+        : path.join(__dirname, 'windows.vbs');
 
     return options;
   },

--- a/src/validation.js
+++ b/src/validation.js
@@ -262,6 +262,17 @@ const validation = {
 
     return options;
   },
+  validateWindowsScript: function (options) {
+    options = this.validateOutputPath(options, "windows");
+    options = this.validateOptionalString(options, "windows", "vbsPath");
+
+    options.windows.vbsPath =
+      "vbsPath" in options.windows
+        ? options.windows.vbsPath
+        : path.join(__dirname, "windows.vbs");
+
+    return options;
+  },
   validateWindowsWindowMode: function (options) {
     options = this.validateOptionalString(options, 'windows', 'windowMode');
 
@@ -356,6 +367,7 @@ const validation = {
     options = this.validateWindowsWindowMode(options);
     options = this.validateWindowsIcon(options);
     options = this.validateWindowsComment(options);
+    options = this.validateWindowsScript(options);
     options = this.validateOptionalString(options, 'windows', 'arguments');
     options = this.validateOptionalString(options, 'windows', 'hotkey');
 


### PR DESCRIPTION
Electron chokes when attempting to load the vbs script required to create a shortcut. This patch addresses that by allowing the default path to be overwritten through the windows-specific options.