### PR TITLE
Enable passing path to VBS file via options

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -139,7 +139,7 @@ const library = {
   makeWindowsShortcut: function (options) {
     let success = true;
 
-    const vbsScript = this.produceWindowsVBSPath();
+    const vbsScript = options.windows.vbsScript || this.produceWindowsVBSPath();
     if (!fs.existsSync(vbsScript)) {
       helpers.throwError(options, 'Could not locate required "windows.vbs" file.');
       success = false;


### PR DESCRIPTION
Could not get this package to work in electron when everything is packed into an asar package, so I worked around this issue by moving the vbs file into my resources folder (so it doesn't get packed) and passing the path to it via options, thought this might be useful for other folks as well