### PR TITLE
Added an option for custom vbs script path

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,8 @@ Key                | Type   | Allowed                                  | Default
 `arguments`        | String | Any string                               | None                         | Additional arguments passed in to the end of your target `filePath`
 `windowMode`       | String | `'normal'`, `'maximized'`, `'minimized'` | `'normal'`                   | How the window should be displayed by default
 `hotkey`           | String | Any string                               | None                         | A global hotkey to associate to opening this shortcut, like `'CTRL+ALT+F'`
-`workingDirectory` | String | Any valid path to a folder               | None                         | The working directory for the shortcut when it launches
+`workingDirectory` | String | Any valid path to an existing folder               | None                         | The working directory for the shortcut when it launches
+`vbsScriptPath` | String | Any valid path to an existing file               | None                         | A path to the script that creates a Windows shortcut.
 
 
 ### Linux Settings

--- a/src/library.js
+++ b/src/library.js
@@ -139,7 +139,7 @@ const library = {
   makeWindowsShortcut: function (options) {
     let success = true;
 
-    const vbsScript = this.produceWindowsVBSPath();
+    const vbsScript = options.windows.vbsScriptPath || this.produceWindowsVBSPath();
     if (!fs.existsSync(vbsScript)) {
       helpers.throwError(options, 'Could not locate required "windows.vbs" file.');
       success = false;

--- a/src/validation.js
+++ b/src/validation.js
@@ -561,6 +561,32 @@ const validation = {
 
     return options;
   },
+
+  /**
+   * Resolves environement variables to absolute paths. Validates
+   * the vbs script path for creating a Windows shortcut exists or removes it.
+   *
+   * @example
+   * options = validateVBSScriptPath(options);
+   *
+   * @param  {object} options  User's options
+   * @return {object}          Validated or mutated user options
+   */
+  validateVBSScriptPath: function (options) {
+    options = this.validateOptionalString(options, 'windows', 'vbsScriptPath');
+    if (!options.windows || !Object(options.windows).hasOwnProperty('vbsScriptPath')) {
+      return options;
+    }
+
+    options.windows.vbsScriptPath = helpers.resolveWindowsEnvironmentVariables(options.windows.vbsScriptPath);
+
+    if (!fs.existsSync(options.windows.vbsScriptPath)) {
+      helpers.throwError(options, 'Optional WINDOWS vbsScriptPath path does not exist: ' + options.windows.vbsScriptPath);
+      delete options.windows.vbsScriptPath;
+      return options;
+    }
+    return options;
+  },
   /**
    * Validates or removes the Windows object from the user's options.
    *
@@ -581,6 +607,7 @@ const validation = {
     options = this.validateWindowsIcon(options);
     options = this.validateWindowsComment(options);
     options = this.validateWindowsWorkingDirectory(options);
+    options = this.validateVBSScriptPath(options);
     options = this.validateOptionalString(options, 'windows', 'arguments');
     options = this.validateOptionalString(options, 'windows', 'hotkey');
 

--- a/tests/src/validation.test.js
+++ b/tests/src/validation.test.js
@@ -1000,6 +1000,61 @@ describe('Validation', () => {
       });
     });
 
+    describe('validateVBSScriptPath', () => {
+      beforeEach(() => {
+        delete options.windows.filePath;
+        delete options.windows.outputPath;
+      });
+
+      test('Empty object', () => {
+        expect(validation.validateVBSScriptPath({}))
+          .toEqual({});
+      });
+
+      test('Empty windows object', () => {
+        expect(validation.validateVBSScriptPath(options))
+          .toEqual({
+            ...defaults,
+            customLogger,
+            windows: {}
+          });
+
+        expect(customLogger)
+          .not.toHaveBeenCalled();
+      });
+
+      test('Path does not exist', () => {
+        options.windows.vbsScriptPath = 'C:\\fake\\path.vbs';
+
+        expect(validation.validateVBSScriptPath(options))
+          .toEqual({
+            ...defaults,
+            customLogger,
+            windows: {}
+          });
+
+        expect(customLogger)
+          .toHaveBeenCalledWith('Optional WINDOWS vbsScriptPath path does not exist: C:\\fake\\path.vbs', undefined);
+      });
+
+
+      test('VBS script exists', () => {
+        options.windows.workingDirectory = 'C:\\Users\\DUMMY\\Desktop\\windows.vbs';
+
+        expect(validation.validateVBSScriptPath(options))
+          .toEqual({
+            ...defaults,
+            customLogger,
+            windows: {
+              workingDirectory: 'C:\\Users\\DUMMY\\Desktop\\windows.vbs'
+            }
+          });
+
+        expect(customLogger)
+          .not.toHaveBeenCalled();
+      });
+    });
+
     describe('validateWindowsWorkingDirectory', () => {
       beforeEach(() => {
         delete options.windows.filePath;

--- a/tests/testHelpers.js
+++ b/tests/testHelpers.js
@@ -161,6 +161,7 @@ const testHelpers = {
       'C:\\Users\\DUMMY\\icon.exe': 'text',
       'C:\\Users\\DUMMY\\icon.dll': 'text',
       'C:\\Users\\DUMMY\\icon.png': 'text',
+      'C:\\Users\\DUMMY\\windows.vbs': 'text',
       'C:\\Users\\DUMMY\\Desktop': {}
     };
     let WindowsInLinuxCI = {


### PR DESCRIPTION
The configuration is intended for bundled applications (like Electron), where `__dirname` points to a file which makes it impossible to use the library