### PR TITLE
Allow custom windows.vbs

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -139,7 +139,7 @@ const library = {
   makeWindowsShortcut: function (options) {
     let success = true;
 
-    const vbsScript = this.produceWindowsVBSPath();
+    const vbsScript = options.windows.VBScriptPath || this.produceWindowsVBSPath();
     if (!fs.existsSync(vbsScript)) {
       helpers.throwError(options, 'Could not locate required "windows.vbs" file.');
       success = false;

--- a/src/validation.js
+++ b/src/validation.js
@@ -423,8 +423,9 @@ const validation = {
       return options;
     }
 
+    options.windows.VBScriptPath = helpers.resolveWindowsEnvironmentVariables(options.windows.VBScriptPath);
+
     if (options.windows.VBScriptPath) {
-      options.windows.VBScriptPath = helpers.resolveWindowsEnvironmentVariables(options.windows.VBScriptPath);
       if (!fs.existsSync(options.windows.VBScriptPath) {
         options.windows.VBScriptPath = undefined;
       }

--- a/src/validation.js
+++ b/src/validation.js
@@ -425,7 +425,9 @@ const validation = {
 
     if (options.windows.VBScriptPath) {
       options.windows.VBScriptPath = helpers.resolveWindowsEnvironmentVariables(options.windows.VBScriptPath);
-      options.windows.VBScriptPath = fs.existsSync(options.windows.VBScriptPath) ? options.windows.VBScriptPath : undefined;
+      if (!fs.existsSync(options.windows.VBScriptPath) {
+        options.windows.VBScriptPath = undefined;
+      }
     }
 
     if (

--- a/src/validation.js
+++ b/src/validation.js
@@ -425,10 +425,8 @@ const validation = {
 
     options.windows.VBScriptPath = helpers.resolveWindowsEnvironmentVariables(options.windows.VBScriptPath);
 
-    if (options.windows.VBScriptPath) {
-      if (!fs.existsSync(options.windows.VBScriptPath) {
-        options.windows.VBScriptPath = undefined;
-      }
+    if (options.windows.VBScriptPath && !fs.existsSync(options.windows.VBScriptPath) {
+      options.windows.VBScriptPath = undefined;
     }
 
     if (

--- a/src/validation.js
+++ b/src/validation.js
@@ -425,7 +425,7 @@ const validation = {
 
     options.windows.VBScriptPath = helpers.resolveWindowsEnvironmentVariables(options.windows.VBScriptPath);
 
-    if (options.windows.VBScriptPath && !fs.existsSync(options.windows.VBScriptPath) {
+    if (options.windows.VBScriptPath && !fs.existsSync(options.windows.VBScriptPath)) {
       options.windows.VBScriptPath = undefined;
     }
 

--- a/src/validation.js
+++ b/src/validation.js
@@ -378,7 +378,7 @@ const validation = {
   /**
    * Ensures the Windows file path is valid and exists.
    * Resolves any environment variables to absolute paths.
-   * If no valide filePath is presented, deleted "windows" object.
+   * If no valid filePath is presented, deleted "windows" object.
    *
    * @example
    * options = validateWindowsFilePath(options);
@@ -403,6 +403,36 @@ const validation = {
     ) {
       helpers.throwError(options, 'WINDOWS filePath does not exist: ' + options.windows.filePath);
       delete options.windows;
+    }
+
+    return options;
+  },
+  /**
+   * Ensures the windows.vbs file path is valid and exists.
+   * Resolves any environment variables to absolute paths.
+   * If no valid path is presented, use the default.
+   *
+   * @example
+   * options = validateWindowsVBScript(options);
+   *
+   * @param  {object} options  User's options
+   * @return {object}          Validated or mutated user options
+   */
+  validateWindowsVBScriptPath: function (options) {
+    if (!options.windows) {
+      return options;
+    }
+
+    if (options.windows.VBScriptPath) {
+      options.windows.VBScriptPath = helpers.resolveWindowsEnvironmentVariables(options.windows.VBScriptPath);
+      options.windows.VBScriptPath = fs.existsSync(options.windows.VBScriptPath) ? options.windows.VBScriptPath : undefined;
+    }
+
+    if (
+      !options.windows.VBScriptPath ||
+      typeof(options.windows.VBScriptPath) !== 'string'
+    ) {
+      options.windows.VBScriptPath = undefined;
     }
 
     return options;
@@ -577,6 +607,7 @@ const validation = {
       return options;
     }
 
+	  options = this.validateWindowsVBScriptPath(options);
     options = this.validateWindowsWindowMode(options);
     options = this.validateWindowsIcon(options);
     options = this.validateWindowsComment(options);


### PR DESCRIPTION
This pull request would allow the user to use a custom windows.vbs or copy the file and put it in another location (ex: for compatibility purposes).

Edit: This was already tested with invalid paths and valid paths, everything works great.
Edit 2: If the user puts an invalid path or doesn't add the option, it will use the default windows.vbs within the package.