### PR TITLE
feat: support create a desktop for link

### DIFF
--- a/api-type-definitions.js
+++ b/api-type-definitions.js
@@ -22,6 +22,7 @@
  * @property {string} [hotkey]               A global hotkey to associate to opening this shortcut, like 'CTRL+ALT+F'.
  * @property {string} [workingDirectory]     The working directory for the shortcut when it launches, must be a valid path to a folder.
  * @property {string} [VBScriptPath]         This is an advanced option specifically and only for projects packaged with `pkg`.
+ * @property {string} [isLink]               This parameter indicates that it is a link or deeplink, It is using either the "http://" or "https://" protocol or a custom deeplink protocol.
  *                                           [See documentation](https://github.com/nwutils/create-desktop-shortcuts#windows-settings).
  */
 

--- a/src/validation.js
+++ b/src/validation.js
@@ -398,7 +398,9 @@ const validation = {
       windowsFilePath = helpers.resolveWindowsEnvironmentVariables(windowsFilePath);
       windowsFilePath = this.resolvePATH(windowsFilePath);
     }
-
+    if(options.windows.isLink){
+      return options;
+    }
     if (
       !windowsFilePath ||
       typeof(windowsFilePath) !== 'string' ||


### PR DESCRIPTION
It should be allowed to create a website or deeplink shortcut for Windows, translated into English