### PR TITLE
Fix empty hotkeys field in shortcut file props

### DIFF
--- a/src/windows.vbs
+++ b/src/windows.vbs
@@ -32,6 +32,7 @@ sub createFile()
   objLink.WorkingDirectory = strCwd
   objLink.IconLocation = strIcon
   objLink.WindowStyle = strWindowMode
+  ' We must skip setting the hotkey if the trimmed value is an empty string to avoid errors (#96).
   If Trim(strHotkey) <> "" Then
     objLink.Hotkey = strHotkey
   End If

--- a/src/windows.vbs
+++ b/src/windows.vbs
@@ -32,7 +32,9 @@ sub createFile()
   objLink.WorkingDirectory = strCwd
   objLink.IconLocation = strIcon
   objLink.WindowStyle = strWindowMode
-  objLink.Hotkey = strHotkey
+  If Trim(strHotkey) <> "" Then
+    objLink.Hotkey = strHotkey
+  End If
   objLink.Save
 end sub
 


### PR DESCRIPTION
When creating a shortcut without passing hotkey options, some apps break when read the shortcut file because the hotkey field is empty like the left example, but without the hotkey arguments in vb script, shortkey field has a corrent windows value witch is "None" as shown on right.

![bento](https://github.com/user-attachments/assets/c545d0dc-52de-415f-aca5-d4f567a99d78)
